### PR TITLE
Fix contact link and provider setup

### DIFF
--- a/__tests__/components/page/index/profile.spec.tsx
+++ b/__tests__/components/page/index/profile.spec.tsx
@@ -22,10 +22,10 @@ describe("Profile component", () => {
 		expect(screen.getByText(mockProps.bio)).toBeInTheDocument();
 		expect(screen.getByText("Contact")).toBeInTheDocument();
 		expect(screen.getByText(mockProps.email)).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: mockProps.email })).toHaveAttribute(
-			"href",
-			"https://twitter.com/test_twitter",
-		);
+                expect(screen.getByRole("link", { name: mockProps.email })).toHaveAttribute(
+                        "href",
+                        `mailto:${mockProps.email}`,
+                );
 
 		expect(
 			screen.getByAltText(

--- a/__tests__/renderer.tsx
+++ b/__tests__/renderer.tsx
@@ -3,5 +3,5 @@ import { render } from "@testing-library/react";
 import type React from "react";
 
 export const renderWithChakra = (ui: React.ReactNode) => {
-	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+        return render(<ChakraProvider theme={defaultSystem}>{ui}</ChakraProvider>);
 };

--- a/src/components/page/index/profile.tsx
+++ b/src/components/page/index/profile.tsx
@@ -52,12 +52,12 @@ const Profile = (props: Props) => {
 				<GridItem>
 					<Stack gap={2} align={"center"}>
 						<Heading size="sm">Contact</Heading>
-						<Link
-							href={props.twitter}
-							target="_blank"
-							rel="noopener noreferrer"
-							variant="underline"
-						>
+                                                <Link
+                                                        href={`mailto:${props.email}`}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        variant="underline"
+                                                >
 							<HStack align="center">
 								<Text>{props.email}</Text>
 								<LuExternalLink />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,9 +13,9 @@ const App = ({ Component, pageProps }: AppProps) => {
 			</Head>
 			<GoogleAnalytics gaId={GA_TRACKING_ID} />
 
-			<ChakraProvider value={defaultSystem}>
-				<Component {...pageProps} />
-			</ChakraProvider>
+                        <ChakraProvider theme={defaultSystem}>
+                                <Component {...pageProps} />
+                        </ChakraProvider>
 		</>
 	);
 };


### PR DESCRIPTION
## Summary
- use `theme` prop for ChakraProvider
- link email address using `mailto:`
- update tests accordingly

## Testing
- `yarn test` *(fails: Error when performing the request ...)*

------
https://chatgpt.com/codex/tasks/task_e_684031eb67f88332841b673c6102e623