### PR TITLE
chore: Next.js 14から15、React 18から19にアップグレード

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,7 @@
-const nextConfig = {
+import type { NextConfig } from "next";
+import webpack from "webpack";
+
+const nextConfig: NextConfig = {
 	output: "export",
 	trailingSlash: true,
 	images: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
 				"@chakra-ui/react": "^3.19.1",
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.0",
-				"@next/third-parties": "^14.2.4",
-				"@types/react": "^18.3.1",
-				"@types/react-dom": "^18.3.1",
+				"@next/third-parties": "^15.3.4",
+				"@types/react": "^19.1.8",
+				"@types/react-dom": "^19.1.6",
 				"framer-motion": "^12.12.1",
-				"next": "14.2.4",
-				"react": "18.3.1",
-				"react-dom": "18.3.1",
+				"next": "^15.3.4",
+				"react": "^19.1.0",
+				"react-dom": "^19.1.0",
 				"react-icons": "^5.5.0"
 			},
 			"devDependencies": {
@@ -57,6 +57,7 @@
 			"version": "5.14.0",
 			"resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.14.0.tgz",
 			"integrity": "sha512-7WWlCM3SowtF01e9NouuO4T6SYuKTM1dovR+2NZuuWTlqTBlvZ+1vPHS6BeqzXriwMLU7QUU+Y0i/TcI6/s/Sg==",
+			"license": "MIT",
 			"dependencies": {
 				"@internationalized/date": "3.8.2",
 				"@zag-js/accordion": "1.15.2",
@@ -685,6 +686,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+			"integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emotion/babel-plugin": {
 			"version": "11.13.5",
 			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -1222,6 +1233,7 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
 			"integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.9"
 			}
@@ -1230,6 +1242,7 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
 			"integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.7.1",
 				"@floating-ui/utils": "^0.2.9"
@@ -1238,12 +1251,410 @@
 		"node_modules/@floating-ui/utils": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+			"license": "MIT"
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
+			"integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
+			"integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
+			"integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
+			"integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
+			"integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
+			"integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
+			"integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
+			"integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
+			"integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
+			"integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
+			"integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
+			"integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
+			"integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
+			"integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
+			"integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
+			"integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.4.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
+			"integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
+			"integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
+			"integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
 		},
 		"node_modules/@internationalized/date": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
 			"integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -1252,6 +1663,7 @@
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.3.tgz",
 			"integrity": "sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -1300,17 +1712,19 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.4.tgz",
-			"integrity": "sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg=="
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.4.tgz",
+			"integrity": "sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==",
+			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.4.tgz",
-			"integrity": "sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.4.tgz",
+			"integrity": "sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1320,12 +1734,13 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
-			"integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.4.tgz",
+			"integrity": "sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1335,12 +1750,13 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
-			"integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.4.tgz",
+			"integrity": "sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1350,12 +1766,13 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
-			"integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.4.tgz",
+			"integrity": "sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1365,12 +1782,13 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
-			"integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.4.tgz",
+			"integrity": "sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1380,12 +1798,13 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
-			"integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.4.tgz",
+			"integrity": "sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1395,27 +1814,13 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
-			"integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.4.tgz",
+			"integrity": "sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==",
 			"cpu": [
 				"arm64"
 			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
-			"integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
-			"cpu": [
-				"ia32"
-			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1425,12 +1830,13 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.4.tgz",
-			"integrity": "sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.4.tgz",
+			"integrity": "sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg==",
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1440,15 +1846,16 @@
 			}
 		},
 		"node_modules/@next/third-parties": {
-			"version": "14.2.30",
-			"resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.30.tgz",
-			"integrity": "sha512-FvQ9rYrAB4KcEiiCek8Zhcwuc7j5E+YCHPjdAzCBaKrtGjTt/9aJ176YzFfxAtRZ1E9h4md3Ghwq/hkl4tEoUQ==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.4.tgz",
+			"integrity": "sha512-jOvAsd0Yoq/eZ3/M+X/y/539/M6Up2xPE/aOr23CGXKinhfK2kscGP4uhtwlS0FZyHvU7ud9HTTt7G3D5G5BkA==",
+			"license": "MIT",
 			"dependencies": {
 				"third-party-capital": "1.0.20"
 			},
 			"peerDependencies": {
-				"next": "^13.0.0 || ^14.0.0",
-				"react": "^18.2.0"
+				"next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+				"react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
 			}
 		},
 		"node_modules/@pandacss/is-valid-prop": {
@@ -1725,7 +2132,8 @@
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.17",
@@ -1904,26 +2312,22 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
 			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
 		},
-		"node_modules/@types/prop-types": {
-			"version": "15.7.15",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
-		},
 		"node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "19.1.8",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+			"integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+			"license": "MIT",
 			"dependencies": {
-				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.3.7",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"version": "19.1.6",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+			"integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+			"license": "MIT",
 			"peerDependencies": {
-				"@types/react": "^18.0.0"
+				"@types/react": "^19.0.0"
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
@@ -2065,6 +2469,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.15.2.tgz",
 			"integrity": "sha512-4ooxmmnEDeRLPLOCsrQeLHcTj+xTqBHm6pYEdho/pb67lHujAUSnbfEryorBSfvJEWdiUTYts96EfsLfbn5SYA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2076,12 +2481,14 @@
 		"node_modules/@zag-js/anatomy": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.15.2.tgz",
-			"integrity": "sha512-GiWZk+fqO/W15FIRVhUL237xZmYMm/gcrp8b4VJGLpZE4qaQaBd4kSYObhIl/7AnLC45VjKbV7c8fLxZKd/5kA=="
+			"integrity": "sha512-GiWZk+fqO/W15FIRVhUL237xZmYMm/gcrp8b4VJGLpZE4qaQaBd4kSYObhIl/7AnLC45VjKbV7c8fLxZKd/5kA==",
+			"license": "MIT"
 		},
 		"node_modules/@zag-js/angle-slider": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.15.2.tgz",
 			"integrity": "sha512-ItcDlKHJbPFfPGmmiCGcWcd0Y8xC+WH5Dji7+uzBl40L9hh8si7/FrY9EB2cX/qUTDppNyicLPIDnZRGkByTOA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2094,12 +2501,14 @@
 		"node_modules/@zag-js/aria-hidden": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.15.2.tgz",
-			"integrity": "sha512-Uwt86QpEaI4qLFS/k4C7rwIfyiH8EdE5a4AWiQ26WsL8VOpjROn65rBEOJ8q3fG5CJXbdcqaYK3lg4ldqf9irQ=="
+			"integrity": "sha512-Uwt86QpEaI4qLFS/k4C7rwIfyiH8EdE5a4AWiQ26WsL8VOpjROn65rBEOJ8q3fG5CJXbdcqaYK3lg4ldqf9irQ==",
+			"license": "MIT"
 		},
 		"node_modules/@zag-js/auto-resize": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.15.2.tgz",
 			"integrity": "sha512-Mg3IN3eIP2wKBFRm5qti/rjKpTj7sfIVNfO9BgWdHDSzli1VwaBX7GaOE3nGc1tZ2nJ8n0SWRvRSzr3b57cwKw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2108,6 +2517,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.15.2.tgz",
 			"integrity": "sha512-4aG2ETJbdMTALyXwU/DeGfjs/dM0Kllje+t5ov52fQrtkY123JdrvKQkcvsc7Luph1kdN1tC1/2fe/pDMhycCg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2120,6 +2530,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.15.2.tgz",
 			"integrity": "sha512-7bcyEtWIhv7kw+V4H+Fv5rE8I8lf0LQOj+m3HTYzWo+wiLybFfI8/bg1qywjSYKsgZr3gmGVCEZhfx3BSpP3eA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2133,6 +2544,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.15.2.tgz",
 			"integrity": "sha512-Ay/+rpKbxL4jE1pwVw52h0t79PpiifA6QlYnV4E+hWl1yJBkMRIi76Ryhqvqp4yY+2Wyr9OfDA9eHmQjapG4VA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2146,6 +2558,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.15.2.tgz",
 			"integrity": "sha512-EE5OlsIYbBklo62qu3A7GiUnsgmoGaoDZvhpYvpNM8StWNeRREcJZXRIizv4aFC46e5eODzSNcebnMLYa8Wcgw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2158,6 +2571,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.15.2.tgz",
 			"integrity": "sha512-vvUXQMFgwsZJphE4Ml5ap4FVhtyLOqK2QXPbt2+F8X8SRwJ3/pqsSsLFdH+ALpNoCK6WF9j+8FZ4lyidr7XPDw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2170,6 +2584,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.15.2.tgz",
 			"integrity": "sha512-bJ9EtZ1Cpjh/rQFDMPTPrky/eSfaLpHWmMnk/S9b7wi+OhC0Hoqw38lcWzfc0AaE4bJsfru9/FLIsCDOLf7TSg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/utils": "1.15.2"
 			}
@@ -2178,6 +2593,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.15.2.tgz",
 			"integrity": "sha512-UOYHECq+X6hSrgSxwBt5O4Y6f2IdOGMhe7P/LFev7Yn0x1F9fMxJZCIzvQGaQ2V/hR0eTatiKk5SmOp9+dJA/g==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/color-utils": "1.15.2",
@@ -2193,6 +2609,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.15.2.tgz",
 			"integrity": "sha512-c167QcxiVHgFZ7ca0PSQZ7skhbBOd6u1lIyWYzkZ2uPf0yJndqP9gFYPMbwK6d4WIM9k6y6mLdsWCGpqIJJsIg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/utils": "1.15.2"
 			}
@@ -2201,6 +2618,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.15.2.tgz",
 			"integrity": "sha512-lZXW99NLnRfLLY1ZOE0oqo4wMDglkUjKV1UZaHyj+yqXsiMtWhKQFQW/JeVBRDe6RCv8wWPPHMycNANMw581gQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/aria-hidden": "1.15.2",
@@ -2217,6 +2635,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.15.2.tgz",
 			"integrity": "sha512-yUnh4I0nZ8rlszWgF402F5vGoYw7DNwStYz2TAO+4E08BpKBATw3FEdqAHPm+2xZm5qPqnPbM4iObwUlkBQUEw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2",
 				"@zag-js/utils": "1.15.2"
@@ -2226,6 +2645,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.15.2.tgz",
 			"integrity": "sha512-KElAFm3fW4GKGUNUe+jqqUX+P1H+Cigp/eGRgIl0dUjCwHocD1oN0ZCwNYmf7SJoWSgPRc1UJdA4XvpdU0IwPQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2245,6 +2665,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.15.2.tgz",
 			"integrity": "sha512-U+HtfdtHJ5ed2ys8izMhu8gY5jQigCd8ExPN5Cxg5CoIbSkho9NT8o/eO9OW71jc2F4kwBh+q0reyxxLJnTSbw==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@internationalized/date": ">=3.0.0"
 			}
@@ -2253,6 +2674,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.15.2.tgz",
 			"integrity": "sha512-LUF+tiiUJj7v24txhC0TOwEgsfj1GCogAmBaiJKxvqrDEDv1B91J0b6SUQ5TuTMLW+hlBEzXZw0QsTxa9OXBew==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/aria-hidden": "1.15.2",
@@ -2269,6 +2691,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.15.2.tgz",
 			"integrity": "sha512-+WY8a1L+L8hXPGmWKqOsSg2KCHabVWXEX8mewHamltpSb86+2WMmblpLNgTwbm6V0T6txf1N8lFuzWMojMEWSg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2",
 				"@zag-js/interact-outside": "1.15.2",
@@ -2279,6 +2702,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.15.2.tgz",
 			"integrity": "sha512-+r9Xj6hiQj9b2ZNkT3E/bDaXgigoAkhtikDXov9duAY14pFFJxazXr0NcVgacik8ytAEt6XOOshLcAftyalRKg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/types": "1.15.2"
 			}
@@ -2287,6 +2711,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.15.2.tgz",
 			"integrity": "sha512-32v7DXDBnDX1CiFpGRh9uclu48UJQJT2QZPQ0Bys3ZOFgMxsWH6tCKDb7iQTcINIc/XIx/9nclWnV5egzimG9w==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2300,6 +2725,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.15.2.tgz",
 			"integrity": "sha512-Zgac/da5QrUlE0ItlNy1kyMXfTy4ynTWnq4aZ4wZ9eVHUFQhLXERv8l+hYJetImISnuclmNVxNKP8Xk+5t4+tA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2314,6 +2740,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.15.2.tgz",
 			"integrity": "sha512-aNUEBJUeK6G3pyf+zYnIMg0GgJnInddjGRedFeTnfK1UmlSO8wTbxQTCvjWd4Nnr5eCTpQkRq6wTZy8JeIcOpw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/i18n-utils": "1.15.2"
 			}
@@ -2322,6 +2749,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.15.2.tgz",
 			"integrity": "sha512-8oG2MRXWWeXws7iVDmJFBqHLHYOGLvYe+vgXI3vgnLhmS4SeX9qAJj6qIOar7htOmEtp1p/KiBo2w2MYtzjuAw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2338,6 +2766,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.15.2.tgz",
 			"integrity": "sha512-5EU5/Cg80oNO3z83A/33t9SOVYvLqLOuSPxt/7Xzy/L1Vj3vUj+s1ox6IpECmEFJcuql7X5yt6VIVitrLtgbFA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2346,6 +2775,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.15.2.tgz",
 			"integrity": "sha512-zElE5T41p5QaB4856xK2SeERmHrKbA/UMzoyHzrAk/N1r6dNiMOOx1hMyHy7y6pEhC9kjJFwEpXi1QEel6/ELA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2353,12 +2783,14 @@
 		"node_modules/@zag-js/highlight-word": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.15.2.tgz",
-			"integrity": "sha512-2a49h4k0ISIDydaZZDdASEHJpwxJeuZHSPCE7cM3/BWCR3H5galeC/jbNWRlTJVH4OQTYAR0I2wILQvOWLhSrw=="
+			"integrity": "sha512-2a49h4k0ISIDydaZZDdASEHJpwxJeuZHSPCE7cM3/BWCR3H5galeC/jbNWRlTJVH4OQTYAR0I2wILQvOWLhSrw==",
+			"license": "MIT"
 		},
 		"node_modules/@zag-js/hover-card": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.15.2.tgz",
 			"integrity": "sha512-FfNmhow8MPMp5RgTeC87x4EStFw+d1137w4QZ+fC5PystRzxGeiyDJyLRYGVeIQO2oP463az70vnxsbFAMu98A==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2373,6 +2805,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.15.2.tgz",
 			"integrity": "sha512-1RnqCaxe+l4UR1O3fhn04T+J62yw/SkCByhrhrPSis/H7a65nW0WsoWiJTIgWp/hN9HI2Y3dVFfMEwQUFFHG1g==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2381,6 +2814,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.15.2.tgz",
 			"integrity": "sha512-WbCICcMJHL6yS8vaou0FvKV6shl1Z+CefF7yzn5MEshPLbmy33WGQ2KBzodTkIQFM/C/zdVz5xKl8TbQmi7jUg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2",
 				"@zag-js/utils": "1.15.2"
@@ -2390,6 +2824,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.15.2.tgz",
 			"integrity": "sha512-V6Zbi8HTiyhsV4GhFaiFYL2bJo4lOt24/SA9M/T5D7ZH+bTm3itPUxYddIBi9w6yRTU0gsorosD2GyFkHjchvg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/collection": "1.15.2",
@@ -2403,12 +2838,14 @@
 		"node_modules/@zag-js/live-region": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.15.2.tgz",
-			"integrity": "sha512-dIrfDlKyNz99CQVeHu9RHe/x+yTBm3wFA7H655DXL7CugO9tpTlynkrTG9AB+0Z84JKZTeHh0vGVa2chTWKrNg=="
+			"integrity": "sha512-dIrfDlKyNz99CQVeHu9RHe/x+yTBm3wFA7H655DXL7CugO9tpTlynkrTG9AB+0Z84JKZTeHh0vGVa2chTWKrNg==",
+			"license": "MIT"
 		},
 		"node_modules/@zag-js/menu": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.15.2.tgz",
 			"integrity": "sha512-54dGUChMLyTrkCGbKGh0R8l/cg0vPFnGZwMG96zYJhkmXdpDMECZgBrN3j7B6RtEIvlAR8fMH5Sya58Amb3lGg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2424,6 +2861,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.15.2.tgz",
 			"integrity": "sha512-qtDAVUdMXBhufBSwAgi8MXm7zHb36ujfWmxCJg6HbjKVF0BEAxeoye5VexgyYul7Hp8+Rr9LkW8X35W4amjJEQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@internationalized/number": "3.6.3",
 				"@zag-js/anatomy": "1.15.2",
@@ -2437,6 +2875,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.15.2.tgz",
 			"integrity": "sha512-k1jT7UWDwgkYVsf83TTUhks6iZ7aQpcEjQ+iWI2LbZu98+bVhX9hpHfxdWbvTbueGk6WjB2xa1X0tsktII1mmQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2449,6 +2888,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/password-input/-/password-input-1.15.2.tgz",
 			"integrity": "sha512-9BpQ26Z9XoCiNAHOmx3zwa+62+C6358/az0h3N24P4qS1EdTVWkhG1tsyPhRElg4v1koavZ40RMUppJQBH+DmA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2461,6 +2901,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.15.2.tgz",
 			"integrity": "sha512-1KjGGmyldtEb4RwwdBTKzbgAwpNT6CyY274LvQC8lTCEUYOBkUmS9OUaKUbwkoluCdmXrugpg/XMulisRmMtgg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2473,6 +2914,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.15.2.tgz",
 			"integrity": "sha512-6cD4eTwwj/bkTCDWVk0dMFqg01iD7qJofRSU3da7nde1Y0TMz8gBlt++GASgCF4p/hPeGLD18GcIF8FKka9IlA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/aria-hidden": "1.15.2",
@@ -2490,6 +2932,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.15.2.tgz",
 			"integrity": "sha512-5uaFW9IU8bj3NdEiyuSp2eVJaPvWoA6/q7Fh423Va8booMYW4k1KFmz2BSxQ3JfK5lt3vPI0X2026gSxTx/vmg==",
+			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "1.7.1",
 				"@zag-js/dom-query": "1.15.2",
@@ -2500,6 +2943,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.15.2.tgz",
 			"integrity": "sha512-cNPJz3qeXdoYFEefxFixZoMDFzqfHsLgmi2ynmRrFlyHzHtFdvKjvS5ywo9YFGNgwKrEddS43n8gl3w3lgqBCA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/core": "1.15.2",
 				"@zag-js/dom-query": "1.15.2",
@@ -2510,6 +2954,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.15.2.tgz",
 			"integrity": "sha512-VPunnrTYiJaHnnCKuh2ZARCnzgTtxYIiNKiUVPWlygsWy2AGg1K3AvVswF2CVfGpwbO4ioyBQO65EZkQiMN/Aw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2522,6 +2967,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.15.2.tgz",
 			"integrity": "sha512-hFtwGGArxVJo7osbY3R73BHIX3Ldb8G4gtNDZ2fGcKAcp+SQg5GXUIBK17ncxJrOC7A1Wp7sdOoYNNOPWe2fYA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2536,6 +2982,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.15.2.tgz",
 			"integrity": "sha512-+V9Y4EZuNITMbA9iJisysqWW+JB3YdlFF6dAomvXN8nuOuj8HE02JHndIeMflDtW6Tz99JcJLS7lNXN7G5uEuw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2549,6 +2996,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.15.2.tgz",
 			"integrity": "sha512-g7F9NyB1MF6ydE9aEr9zLPXGKXZIH2ZsUBXEQ9u6apUhnchhCSHDw6xHVXI1hYGrJHnpf2xMw3Xu1opJge1DQg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2561,6 +3009,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.15.2.tgz",
 			"integrity": "sha512-T5QPiLbW4DoQ32NS5+Qu9NsIXKKz0d5MOpfEdXXuc6hKZdvV+V9d7EXeHBRohs3P6jqtf8FXpXDdK2trv37YlQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/core": "1.15.2",
 				"@zag-js/store": "1.15.2",
@@ -2575,12 +3024,14 @@
 		"node_modules/@zag-js/rect-utils": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.15.2.tgz",
-			"integrity": "sha512-wPsOM4qYncwOli20MNINgl0ZwmMY11RvrgPvjcMrkJ9dVqU/YrCcXV4rIg8Zig5jxCT+mf7rWQe9aQJlNTVipA=="
+			"integrity": "sha512-wPsOM4qYncwOli20MNINgl0ZwmMY11RvrgPvjcMrkJ9dVqU/YrCcXV4rIg8Zig5jxCT+mf7rWQe9aQJlNTVipA==",
+			"license": "MIT"
 		},
 		"node_modules/@zag-js/remove-scroll": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.15.2.tgz",
 			"integrity": "sha512-pXVuvFcAQND+C0KAzAve02hGaI/AgEhC7RpgpyUKaUzEccEsxLi40C88j1/2HCfta6GI7nd2e0QwPZiqngUIyA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2589,6 +3040,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.15.2.tgz",
 			"integrity": "sha512-RswpsMHg0aWHsx7xqybnPm8bTL9ow17z9GhYgxSWtIi2U9wgkUHDtEJQcRNUA9PQEGyVd29B39NM0ir64HAhNQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/dom-query": "1.15.2"
 			}
@@ -2597,6 +3049,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.15.2.tgz",
 			"integrity": "sha512-Y07RlBIc8bVj2WklhS7tiVySZntBv9TE9sfiA8RcLU7KFFGTdS2XUoQV4fziJubUL8XFhNzEC92/bKeBLqpgDw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/collection": "1.15.2",
@@ -2612,6 +3065,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.15.2.tgz",
 			"integrity": "sha512-vw7oD7afBfGvUyotJrFl+PjPVYOYZLgQ1eVAosKj54phgKvxheBr8/ySq9vlyTkyvOMjJ8zIkkxlywuqoZzl8g==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2625,6 +3079,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.15.2.tgz",
 			"integrity": "sha512-Lcrm+h4Vx0stD0ybAqD5tA1qOnrKEfQP9ucQsPUy+fY2em19XC6raOVOhAc6ROx4X0neTI/yEc1ARJQSaxtRZw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2637,6 +3092,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.15.2.tgz",
 			"integrity": "sha512-LIuTTPRaw3inS64f2TLcFIlwjNe9Tx9mSE4VXf7wPhYitNKmyh7MeNE59na+wDzZisVwx9yBewAPfrZtbHDGBA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2649,6 +3105,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.15.2.tgz",
 			"integrity": "sha512-NnS3wYQrFWA5OXu+jnlnPpm49rGpzHCDbN2UuUcMGvbYVETKEXEO9fC1XWh7PstVuNi03E/CrZGHl5cEjf/j8w==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2661,6 +3118,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.15.2.tgz",
 			"integrity": "sha512-oDJuRdu8SaGab06UycN96OgvNau1ynawDNNfQNhA7zoOIZlaJH6jP+5YaAPFila+wyjdw7svz5+4ejs8vXcjpw==",
+			"license": "MIT",
 			"dependencies": {
 				"proxy-compare": "3.0.1"
 			}
@@ -2669,6 +3127,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.15.2.tgz",
 			"integrity": "sha512-2aEm5HDP/ENcLvoP77CH7DQTPXIMUzVilefHlz6WT0tQxQzOw8uMhUOYYcuNmEq0FNRUOyuMEMyZnZFUYAxqvQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2682,6 +3141,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.15.2.tgz",
 			"integrity": "sha512-SJMR4K59sxvNZEIgnJfbweLzncmgxRWTBm+FamwMtP8DKQ3RETNdjrn4aA9qLUsCObapk06KT3iTeiCXzuBaFA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2694,6 +3154,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.15.2.tgz",
 			"integrity": "sha512-/mAuB8emhGoo3eoIgmlT/kQE27ukRlhghgwp3OjvEen+iTpz0XIWM+S+IV3QU6U4DlhwkadQaINht/c9ln6gxQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/auto-resize": "1.15.2",
@@ -2709,6 +3170,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/time-picker/-/time-picker-1.15.2.tgz",
 			"integrity": "sha512-Aoe9GdbrvAMP1fdOEmzCESr/dO+cGnqhCoa0UkZB5wuB4dT3S02hRGSZsHO51Eon2NpzHPG9j+/alncwOe77Tw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2726,6 +3188,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.15.2.tgz",
 			"integrity": "sha512-v8RN3cwFuNXxuDMuxxfXKCSd+Z1UT6Ct+ueU3PRZqHqXU9u4k9Mm+vROIqnNzhCCdIHNxsqUt32/2zsRRaubbw==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2738,6 +3201,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.15.2.tgz",
 			"integrity": "sha512-OohJvGTy+J1MpydJ4eCV36picggfF9VbDW4nK97TT+4bIIRDgW+PGYgB4dd+PvEjRrk9194Kkm93lud95yOyZg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2751,6 +3215,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.15.2.tgz",
 			"integrity": "sha512-wtDeIRhDeVhaUboWQ2GrxlCC4+cLRyZzvZiN84tad7H/sUKq9hNDdROcCnIYBhEkb1Qf4sjR8KszY12YLtJx6A==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2763,6 +3228,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.15.2.tgz",
 			"integrity": "sha512-JhWV0GY2NRgDhlzP73ADlG1E4NFXqv1h2q5+m3Rmos+Bi8soOV437jch/wy+M+xYN5vdZCczXJu9BumHNlknhA==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2775,6 +3241,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.15.2.tgz",
 			"integrity": "sha512-Spw5ewga3DNaT5H4AnrtsxJ6ebRoTxy+igwojGTYUCNUoxyQn6W3UpqZpgAAfw8B236bduTRh9MW9CsaM/hnmg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2790,6 +3257,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.15.2.tgz",
 			"integrity": "sha512-OW+autOwwsVMGwcYCxdCh3Hibeeag6Sg8w02XfmX7E+T2u9a+GGdLOrH7DPM2oHTbZV0iBUqIaKxGPKgRYZNng==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/core": "1.15.2",
@@ -2806,6 +3274,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.15.2.tgz",
 			"integrity": "sha512-HWDHH3rpGEz3IN5bsj8EHZnU0ttk8uJwBOnH3reYcFQEQskA8cmyzd7y9hdBEn8PzAns+iOjUBj49IVmoYpOIg==",
+			"license": "MIT",
 			"dependencies": {
 				"@zag-js/anatomy": "1.15.2",
 				"@zag-js/collection": "1.15.2",
@@ -2819,6 +3288,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.15.2.tgz",
 			"integrity": "sha512-qEHNRA/uOYQjvXzI/ie6vuOD74/p7w6MA4X1VoZEYF2/sbIQjlRn6SzpeV3RyFZBzl6WBO6RqV/XEbgpvGSb5w==",
+			"license": "MIT",
 			"dependencies": {
 				"csstype": "3.1.3"
 			}
@@ -2826,7 +3296,8 @@
 		"node_modules/@zag-js/utils": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.15.2.tgz",
-			"integrity": "sha512-JdlyGT6yfG2ub2FftrB6BidIlvD04cSwdKYJGb/M+NJ7p7uxnZUZMxAjeBmTLhM1nWbtJPVq3oDTYz/cBBZLng=="
+			"integrity": "sha512-JdlyGT6yfG2ub2FftrB6BidIlvD04cSwdKYJGb/M+NJ7p7uxnZUZMxAjeBmTLhM1nWbtJPVq3oDTYz/cBBZLng==",
+			"license": "MIT"
 		},
 		"node_modules/agent-base": {
 			"version": "7.1.3",
@@ -3039,13 +3510,28 @@
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+			"license": "MIT"
+		},
+		"node_modules/color": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"color-convert": "^2.0.1",
+				"color-string": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.5.0"
+			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -3057,7 +3543,18 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"devOptional": true
+		},
+		"node_modules/color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -3190,6 +3687,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+			"integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dom-accessibility-api": {
@@ -3523,11 +4030,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3766,17 +4268,6 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
-		},
 		"node_modules/loupe": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
@@ -3887,40 +4378,42 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "14.2.4",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.2.4.tgz",
-			"integrity": "sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==",
+			"version": "15.3.4",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.3.4.tgz",
+			"integrity": "sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==",
+			"license": "MIT",
 			"dependencies": {
-				"@next/env": "14.2.4",
-				"@swc/helpers": "0.5.5",
+				"@next/env": "15.3.4",
+				"@swc/counter": "0.1.3",
+				"@swc/helpers": "0.5.15",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
-				"graceful-fs": "^4.2.11",
 				"postcss": "8.4.31",
-				"styled-jsx": "5.1.1"
+				"styled-jsx": "5.1.6"
 			},
 			"bin": {
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": ">=18.17.0"
+				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.2.4",
-				"@next/swc-darwin-x64": "14.2.4",
-				"@next/swc-linux-arm64-gnu": "14.2.4",
-				"@next/swc-linux-arm64-musl": "14.2.4",
-				"@next/swc-linux-x64-gnu": "14.2.4",
-				"@next/swc-linux-x64-musl": "14.2.4",
-				"@next/swc-win32-arm64-msvc": "14.2.4",
-				"@next/swc-win32-ia32-msvc": "14.2.4",
-				"@next/swc-win32-x64-msvc": "14.2.4"
+				"@next/swc-darwin-arm64": "15.3.4",
+				"@next/swc-darwin-x64": "15.3.4",
+				"@next/swc-linux-arm64-gnu": "15.3.4",
+				"@next/swc-linux-arm64-musl": "15.3.4",
+				"@next/swc-linux-x64-gnu": "15.3.4",
+				"@next/swc-linux-x64-musl": "15.3.4",
+				"@next/swc-win32-arm64-msvc": "15.3.4",
+				"@next/swc-win32-x64-msvc": "15.3.4",
+				"sharp": "^0.34.1"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
 				"@playwright/test": "^1.41.2",
-				"react": "^18.2.0",
-				"react-dom": "^18.2.0",
+				"babel-plugin-react-compiler": "*",
+				"react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+				"react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
@@ -3930,18 +4423,21 @@
 				"@playwright/test": {
 					"optional": true
 				},
+				"babel-plugin-react-compiler": {
+					"optional": true
+				},
 				"sass": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/next/node_modules/@swc/helpers": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-			"integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+			"integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@swc/counter": "^0.1.3",
-				"tslib": "^2.4.0"
+				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/node-releases": {
@@ -4029,7 +4525,8 @@
 		"node_modules/perfect-freehand": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.2.tgz",
-			"integrity": "sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ=="
+			"integrity": "sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==",
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -4110,12 +4607,14 @@
 		"node_modules/proxy-compare": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
-			"integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="
+			"integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+			"license": "MIT"
 		},
 		"node_modules/proxy-memoize": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
 			"integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+			"license": "MIT",
 			"dependencies": {
 				"proxy-compare": "^3.0.0"
 			}
@@ -4148,26 +4647,24 @@
 			"dev": true
 		},
 		"node_modules/react": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+			"integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+			"integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+			"license": "MIT",
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.2"
+				"scheduler": "^0.26.0"
 			},
 			"peerDependencies": {
-				"react": "^18.3.1"
+				"react": "^19.1.0"
 			}
 		},
 		"node_modules/react-icons": {
@@ -4302,12 +4799,10 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			}
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",
@@ -4318,11 +4813,83 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/sharp": {
+			"version": "0.34.2",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
+			"integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"color": "^4.2.3",
+				"detect-libc": "^2.0.4",
+				"semver": "^7.7.2"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.34.2",
+				"@img/sharp-darwin-x64": "0.34.2",
+				"@img/sharp-libvips-darwin-arm64": "1.1.0",
+				"@img/sharp-libvips-darwin-x64": "1.1.0",
+				"@img/sharp-libvips-linux-arm": "1.1.0",
+				"@img/sharp-libvips-linux-arm64": "1.1.0",
+				"@img/sharp-libvips-linux-ppc64": "1.1.0",
+				"@img/sharp-libvips-linux-s390x": "1.1.0",
+				"@img/sharp-libvips-linux-x64": "1.1.0",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
+				"@img/sharp-libvips-linuxmusl-x64": "1.1.0",
+				"@img/sharp-linux-arm": "0.34.2",
+				"@img/sharp-linux-arm64": "0.34.2",
+				"@img/sharp-linux-s390x": "0.34.2",
+				"@img/sharp-linux-x64": "0.34.2",
+				"@img/sharp-linuxmusl-arm64": "0.34.2",
+				"@img/sharp-linuxmusl-x64": "0.34.2",
+				"@img/sharp-wasm32": "0.34.2",
+				"@img/sharp-win32-arm64": "0.34.2",
+				"@img/sharp-win32-ia32": "0.34.2",
+				"@img/sharp-win32-x64": "0.34.2"
+			}
+		},
+		"node_modules/sharp/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"node_modules/simple-swizzle/node_modules/is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/source-map": {
 			"version": "0.5.7",
@@ -4393,9 +4960,10 @@
 			"license": "MIT"
 		},
 		"node_modules/styled-jsx": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-			"integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+			"integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+			"license": "MIT",
 			"dependencies": {
 				"client-only": "0.0.1"
 			},
@@ -4403,7 +4971,7 @@
 				"node": ">= 12.0.0"
 			},
 			"peerDependencies": {
-				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -4604,7 +5172,8 @@
 		"node_modules/uqr": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
-			"integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
+			"integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
+			"license": "MIT"
 		},
 		"node_modules/url-parse": {
 			"version": "1.5.10",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
 		"@chakra-ui/react": "^3.19.1",
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.0",
-		"@next/third-parties": "^14.2.4",
-		"@types/react": "^18.3.1",
-		"@types/react-dom": "^18.3.1",
+		"@next/third-parties": "^15.3.4",
+		"@types/react": "^19.1.8",
+		"@types/react-dom": "^19.1.6",
 		"framer-motion": "^12.12.1",
-		"next": "14.2.4",
-		"react": "18.3.1",
-		"react-dom": "18.3.1",
+		"next": "^15.3.4",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0",
 		"react-icons": "^5.5.0"
 	}
 }


### PR DESCRIPTION
## Summary
- Next.js 14.2.4から15.3.4にアップグレード
- React 18.3.1から19.1.0にアップグレード
- 関連する依存関係（@types/react、@types/react-dom、@next/third-parties）も更新
- ビルドとテストが正常に動作することを確認済み

## Test Plan
- [x] ビルドが正常に完了する
- [x] テストが全て通る
- [x] lintチェックが通る

🤖 Generated with [Claude Code](https://claude.ai/code)