### PR TITLE
feat: Cloudflare Pages デプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -49,7 +49,7 @@ jobs:
 | Item | Value |
 |------|-------|
 | **Preview URL** | [${previewUrl}](${previewUrl}) |
-| **Latest Commit** | [\`${commitSha}\`](${commitUrl}) |
+| **Latest Commit** | [\\\`${commitSha}\\\`](${commitUrl}) |
 | **Build Time** | ${buildTime} |
 
 ---

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,0 +1,85 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.number }}
+
+      - name: Update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.pull_request.head.sha}`;
+            const buildTime = new Date().toISOString();
+            const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
+            
+            const commentBody = `## 🚀 Preview Environment
+
+| Item | Value |
+|------|-------|
+| **Preview URL** | [${previewUrl}](${previewUrl}) |
+| **Latest Commit** | [\`${commitSha}\`](${commitUrl}) |
+| **Build Time** | ${buildTime} |
+
+---
+*This comment is automatically updated on each push.*`;
+
+            // Find existing comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingComment = comments.data.find(comment => 
+              comment.body && comment.body.includes('🚀 Preview Environment')
+            );
+
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody,
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+            }

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,17 +1,14 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  workflow_run:
-    workflows: ["Lint"]
-    types:
-      - completed
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches-ignore:
+      - master
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       pull-requests: write
@@ -19,8 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,15 +35,15 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.workflow_run.pull_requests[0].number }}
+          command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.number }}
 
       - name: Update PR comment
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.workflow_run.pull_requests[0].number;
-            const commitSha = context.payload.workflow_run.head_sha.substring(0, 7);
-            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.workflow_run.head_sha}`;
+            const prNumber = context.payload.pull_request.number;
+            const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.pull_request.head.sha}`;
             const buildTime = new Date().toISOString();
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
 

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,12 +1,17 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Lint"]
+    types:
+      - completed
+    branches:
+      - '**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       pull-requests: write
@@ -14,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -33,15 +40,15 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.number }}
+          command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.workflow_run.pull_requests[0].number }}
 
       - name: Update PR comment
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
-            const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
-            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.pull_request.head.sha}`;
+            const prNumber = context.payload.workflow_run.pull_requests[0].number;
+            const commitSha = context.payload.workflow_run.head_sha.substring(0, 7);
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.workflow_run.head_sha}`;
             const buildTime = new Date().toISOString();
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
 

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -32,6 +32,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy out --project-name ${{ secrets.CF_PROJECT_NAME }} --branch pr-${{ github.event.number }}
 
       - name: Update PR comment
@@ -43,7 +44,7 @@ jobs:
             const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.pull_request.head.sha}`;
             const buildTime = new Date().toISOString();
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
-            
+
             const commentBody = \`## 🚀 Preview Environment
 
             | Item | Value |
@@ -62,7 +63,7 @@ jobs:
               issue_number: prNumber,
             });
 
-            const existingComment = comments.data.find(comment => 
+            const existingComment = comments.data.find(comment =>
               comment.body && comment.body.includes('🚀 Preview Environment')
             );
 

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -45,16 +45,16 @@ jobs:
             const buildTime = new Date().toISOString();
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
 
-            const commentBody = \`## 🚀 Preview Environment
+            const commentBody = `## 🚀 Preview Environment
 
             | Item | Value |
             |------|-------|
             | **Preview URL** | [${previewUrl}](${previewUrl}) |
-            | **Latest Commit** | [\\\\\`${commitSha}\\\\\`](${commitUrl}) |
+            | **Latest Commit** | [\`${commitSha}\`](${commitUrl}) |
             | **Build Time** | ${buildTime} |
 
             ---
-            *This comment is automatically updated on each push.*\`;
+            *This comment is automatically updated on each push.*`;
 
             // Find existing comment
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -44,16 +44,16 @@ jobs:
             const buildTime = new Date().toISOString();
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
             
-            const commentBody = `## 🚀 Preview Environment
+            const commentBody = \`## 🚀 Preview Environment
 
-| Item | Value |
-|------|-------|
-| **Preview URL** | [${previewUrl}](${previewUrl}) |
-| **Latest Commit** | [\\\`${commitSha}\\\`](${commitUrl}) |
-| **Build Time** | ${buildTime} |
+            | Item | Value |
+            |------|-------|
+            | **Preview URL** | [${previewUrl}](${previewUrl}) |
+            | **Latest Commit** | [\\\\\`${commitSha}\\\\\`](${commitUrl}) |
+            | **Build Time** | ${buildTime} |
 
----
-*This comment is automatically updated on each push.*`;
+            ---
+            *This comment is automatically updated on each push.*\`;
 
             // Find existing comment
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -3,8 +3,6 @@ name: Deploy to Cloudflare Pages
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches-ignore:
-      - master
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -42,7 +42,7 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
             const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.payload.pull_request.head.sha}`;
-            const buildTime = new Date().toISOString();
+            const buildTime = new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
             const previewUrl = `https://pr-${prNumber}.${{ secrets.CF_PROJECT_NAME }}.pages.dev`;
 
             const commentBody = `## 🚀 Preview Environment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
-on:
-  push:
-  pull_request:
+on: push
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- pull_request イベント（opened/synchronize/reopened）でプレビュー環境を自動デプロイ
- PR にプレビューURL、最新コミット情報、ビルド日時を Markdown テーブルで表示
- 既存のプレビューコメントがある場合は更新、なければ新規作成
- Node.js バージョンは `.node-version` ファイルから自動取得

## 必要な GitHub Secrets
- `CLOUDFLARE_API_TOKEN`: Cloudflare API トークン
- `CF_PROJECT_NAME`: Cloudflare Pages プロジェクト名

## Test plan
- [ ] GitHub Secrets を設定する
- [ ] このPRをマージしてワークフローをテストする
- [ ] 別のPRを作成してプレビュー環境が正しく動作することを確認する

🤖 Generated with [Claude Code](https://claude.ai/code)