### PR TITLE
fix: Dependabot実行時のCloudflare Pagesデプロイをスキップ

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
DependabotはsecretsにアクセスできないためCLOUDFLARE_API_TOKENが展開されずエラーになる問題を修正

## Changes
- `github.actor \!= 'dependabot[bot]'` 条件でDependabot実行時はデプロイ処理をスキップ

## Test plan
- [ ] Dependabot PRでワークフローがスキップされることを確認
- [ ] 通常のPRでワークフローが正常実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)