### PR TITLE
[codex] chore: add pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 1440


### PR DESCRIPTION
## What
- `pnpm-workspace.yaml` を追加し、`minimumReleaseAge: 1440` を設定
- 新規公開直後のパッケージを 24 時間待ってから解決するように変更

## Why
- 依存パッケージ公開直後の事故やサプライチェーンリスクを避けやすくするため
- pnpm 11 系の既定値に近い設定を、現行の `pnpm@10.28.0` でも明示しておきたいため

## 考えたこと / 判断基準
- このリポジトリは個人サイトで、更新速度より安定性を少し優先するのが妥当
- 24 時間なら安全性と更新追従のバランスがよく、Dependabot の daily 更新とも相性がよい
- 確認: `pnpm config get minimumReleaseAge`, `pnpm lint`, `pnpm test`
