### PR TITLE
[codex] Zed向けOxc設定を追加

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,105 @@
+{
+	"auto_install_extensions": {
+		"oxc": true
+	},
+	"lsp": {
+		"oxfmt": {
+			"initialization_options": {
+				"settings": {
+					"fmt.configPath": ".oxfmtrc.json",
+					"run": "onSave"
+				}
+			}
+		},
+		"oxlint": {
+			"initialization_options": {
+				"settings": {
+					"configPath": ".oxlintrc.json",
+					"fixKind": "safe_fix",
+					"run": "onType"
+				}
+			}
+		}
+	},
+	"languages": {
+		"TypeScript": {
+			"format_on_save": "on",
+			"formatter": [
+				{
+					"language_server": {
+						"name": "oxfmt"
+					}
+				},
+				{
+					"code_action": "source.fixAll.oxc"
+				}
+			]
+		},
+		"TSX": {
+			"format_on_save": "on",
+			"formatter": [
+				{
+					"language_server": {
+						"name": "oxfmt"
+					}
+				},
+				{
+					"code_action": "source.fixAll.oxc"
+				}
+			]
+		},
+		"JavaScript": {
+			"format_on_save": "on",
+			"formatter": [
+				{
+					"language_server": {
+						"name": "oxfmt"
+					}
+				},
+				{
+					"code_action": "source.fixAll.oxc"
+				}
+			]
+		},
+		"CSS": {
+			"format_on_save": "on",
+			"formatter": {
+				"language_server": {
+					"name": "oxfmt"
+				}
+			}
+		},
+		"JSON": {
+			"format_on_save": "on",
+			"formatter": {
+				"language_server": {
+					"name": "oxfmt"
+				}
+			}
+		},
+		"JSONC": {
+			"format_on_save": "on",
+			"formatter": {
+				"language_server": {
+					"name": "oxfmt"
+				}
+			}
+		},
+		"Markdown": {
+			"format_on_save": "on",
+			"formatter": {
+				"language_server": {
+					"name": "oxfmt"
+				}
+			}
+		},
+		"YAML": {
+			"format_on_save": "on",
+			"formatter": {
+				"language_server": {
+					"name": "oxfmt"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

- .zed/settings.json を追加
- ZedでOxc拡張を自動インストール
- 保存時にOxfmtとOxlintの安全な自動修正を実行

## Why

- VS Codeと同等のOxcベースのフォーマット・Lint修正をZedでも利用可能にするため

## 考えたこと / 判断基準

- 既存の.vscode設定は維持し、Zed向け設定のみ追加
- TypeScript、TSX、JavaScriptではOxfmtの後にOxlintの安全な修正を実行
- CSS、JSON、JSONC、Markdown、YAMLではOxfmtのみ実行
- テスト: pnpm check、pnpm test、pre-push hook