### PR TITLE
chore: ignore Next.js generated types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ typings/
 build/
 
 .next
+next-env.d.ts
 out/
 
 # Local Netlify folder

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What

- `next-env.d.ts` を `.gitignore` に追加
- 生成済みファイルをローカルに残したまま Git の追跡対象から解除

## Why

- Next.js が自動生成する型定義ファイルの環境差分を Git 管理から除外するため

## 考えたこと / 判断基準

- Next.js のビルド出力と同じ位置に ignore ルールを配置
- `pnpm check`、`pnpm test`、`pnpm build` を実行し、ビルド後もファイルが存在しつつ ignore・index 非登録の状態を確認
